### PR TITLE
CHANGED: html form tags to closing DIVS

### DIFF
--- a/bb-page-settings/bb-page-settings.php
+++ b/bb-page-settings/bb-page-settings.php
@@ -198,8 +198,8 @@ class BB_Page_Settings {
                         </div>
                     </form>
 
-                </form>
-            </form>
+                </div>
+            </div>
             <?php
         }
     }


### PR DESCRIPTION
There were two closing `</form>` tags instead of `</divs>`. All fixed. ;)
